### PR TITLE
Make the placeholder image URL protocol relative

### DIFF
--- a/lib/phrasing_plus/dummy_image.rb
+++ b/lib/phrasing_plus/dummy_image.rb
@@ -9,7 +9,7 @@ module PhrasingPlus
     end
 
     def url
-      "http://placehold.it/#{size}/#{BG_COLOR}/#{COLOR}"
+      "//placehold.it/#{size}/#{BG_COLOR}/#{COLOR}"
     end
 
     private


### PR DESCRIPTION
As mentioned in #1, the current placeholder image URL breaks https websites.

Since placehold.it supports SSL, using protocol relative URLs fixes the problem.
